### PR TITLE
Bump winston-papertrail to v1.0.1.

### DIFF
--- a/package.js
+++ b/package.js
@@ -4,7 +4,7 @@ Package.describe({
 
 Npm.depends({
     "winston": "0.7.2",
-    "winston-papertrail": "0.1.4"
+    "winston-papertrail": "1.0.1"
 });
 
 Package.on_use(function (api, where) {


### PR DESCRIPTION
I tried this on my local dev machine and was able to push logs to papertrail. I didn't do any more thorough testing than that.

This version introduces some real improvements to the winston-papertrail transport. The log level is now passed through to papertrail as the syslog severity. That means, it's possible to filter by log level in the papertrail interface like `severity:error` which is great for alerting and so on. :-)
